### PR TITLE
Jordan callingcode fixed

### DIFF
--- a/src/constants/countries.json
+++ b/src/constants/countries.json
@@ -823,7 +823,7 @@
 		"unicode": "U+1F1EF U+1F1F4",
 		"name": "Jordan",
 		"emoji": "🇯🇴",
-		"callingCode": "441"
+		"callingCode": "962"
 	},
 	{
 		"code": "JP",


### PR DESCRIPTION
Jordan country calling code changed `441` to `962`